### PR TITLE
- Fix wrong logic in scheduling jobs fist-in-first-out

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -592,10 +592,10 @@ int main(int argc, char **argv)
 
         /* Inform the daemon that we like to start a job.  */
         if (local_daemon->send_msg(JobLocalBeginMsg(0, get_absfilename(job.outputFile()),fulljob))) {
-            /* Now wait until the daemon gives us the start signal.  40 minutes
-               should be enough for all normal compile or link jobs, but with expensive jobs
-               (which fulljobs may likely be, e.g. LTO linking) use an even larger timeout.  */
-            startme = local_daemon->get_msg(fulljob ? 120 * 60 : 40 * 60);
+            // Now wait until the daemon gives us the start signal. This can take a while on 
+            // big projects with many scheduled linker jobs waiting to run locally. So use a 
+            // large timeout of 120 minutes.
+            startme = local_daemon->get_msg(120 * 60);
         }
 
         /* If we can't talk to the daemon anymore we need to fall back

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -314,8 +314,8 @@ public:
         uint32_t min_niceness = std::numeric_limits<uint32_t>::max();
 
         for (auto it : *this) {
-            if (it.second->status == s && (!min_client_id || min_client_id > it.second->client_id)
-                && it.second->niceness < min_niceness ) {
+            if ( (it.second->status == s) 
+            && ((it.second->niceness < min_niceness) || ((it.second->niceness == min_niceness) && (it.second->client_id < min_client_id))) ) {
                 client = it.second;
                 min_client_id = client->client_id;
                 min_niceness = client->niceness;


### PR DESCRIPTION
- Increase remote job timeout to 120 minutes in any case
- Fix broken file locking